### PR TITLE
CI: fix build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,19 +18,25 @@ jobs:
         with:
           python-version: '3.10'
       - name: Build Cairo x86
-        run: python build-cairo.py --prefix="./prefix-cairo-32" --build-cairo --no-build-pkgconf --arch=32
+        run: |
+          $env:PATH = "$env:pythonLocation;$env:ProgramFiles\Git\bin;$env:ProgramFiles\Git\usr\bin;$env:SystemRoot\system32;$env:SystemRoot;$env:SystemRoot\System32\Wbem"
+          python build-cairo.py --prefix="./prefix-cairo-32" --build-cairo --no-build-pkgconf --arch=32
       - uses: actions/upload-artifact@v3
         with:
           name: cairo-build-x86
           path: prefix-cairo-32/
       - name: Build Cairo x64
-        run: python build-cairo.py --prefix="./prefix-cairo-64" --build-cairo --no-build-pkgconf --arch=64
+        run: |
+          $env:PATH = "$env:pythonLocation;$env:ProgramFiles\Git\bin;$env:ProgramFiles\Git\usr\bin;$env:SystemRoot\system32;$env:SystemRoot;$env:SystemRoot\System32\Wbem"
+          python build-cairo.py --prefix="./prefix-cairo-64" --build-cairo --no-build-pkgconf --arch=64
       - uses: actions/upload-artifact@v3
         with:
           name: cairo-build-x64
           path: prefix-cairo-64/
       - name: Build pkgconf
-        run: python build-cairo.py --prefix="./prefix-pkgconf" --build-pkgconf --no-build-cairo
+        run: |
+          $env:PATH = "$env:pythonLocation;$env:ProgramFiles\Git\bin;$env:ProgramFiles\Git\usr\bin;$env:SystemRoot\system32;$env:SystemRoot;$env:SystemRoot\System32\Wbem"
+          python build-cairo.py --prefix="./prefix-pkgconf" --build-pkgconf --no-build-cairo
       - uses: actions/upload-artifact@v3
         with:
           name: pkgconf-build


### PR DESCRIPTION
There is now a C:\Strawberry\* thing in PATH on the GHA image which provides things like zlib and which breaks the build.

This reduces PATH to the default + git + python. Ideas on how to improve that welcome.